### PR TITLE
punctuation correction

### DIFF
--- a/ew_b5_1580.xml
+++ b/ew_b5_1580.xml
@@ -84,7 +84,7 @@
             of them until I get back.<lb/>
          </p>
          <p rend="indent">
-            This is the <choice><abbr>Supt.</abbr><expan>Superintendent</expan></choice> address.<lb/>
+            This is the <choice><abbr>Supt.</abbr><expan>Superintendent</expan></choice> address,<lb/>
             <name type="person"><choice><abbr>Dr.</abbr><expan>Doctor</expan></choice> J. Q. Folmar</name>, <name type="place" subtype="address"><choice><abbr>Fla.</abbr><expan>Florida</expan></choice> State <choice><abbr>Hospt.</abbr><expan>Hospital</expan></choice><lb/></name>
          </p>
          <p>


### PR DESCRIPTION
In the original document, the punctuation after “address” appears to be
a comma.
